### PR TITLE
Rearchitected to avoid per-frame memory allocation.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "potassium-action-input",
+  "name": "action-input",
   "version": "1.0.0",
   "description": "A framework-agnostic input library.",
   "main": "",
@@ -15,11 +15,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/potassiumes/action-input.git"
+    "url": "git+https://github.com/PotassiumES/action-input.git"
   },
   "author": "Mozilla",
   "bugs": {
-    "url": "https://github.com/potassiumes/action-input/issues"
+    "url": "https://github.com/PotassiumES/action-input/issues"
   },
   "prettier": {
     "printWidth": 120

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "action-input",
-  "version": "0.1.0",
+  "name": "potassium-action-input",
+  "version": "1.0.0",
   "description": "A framework-agnostic input library.",
   "main": "",
   "license": "MPL-2.0",
@@ -15,11 +15,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mozilla/action-input.git"
+    "url": "git+https://github.com/potassiumes/action-input.git"
   },
   "author": "Mozilla",
   "bugs": {
-    "url": "https://github.com/mozilla/action-input/issues"
+    "url": "https://github.com/potassiumes/action-input/issues"
   },
   "prettier": {
     "printWidth": 120

--- a/src/MemoryUtils.js
+++ b/src/MemoryUtils.js
@@ -1,0 +1,25 @@
+
+/**
+* Utility methods that perform common tasks without allocation
+*/
+
+const split = function(input, separator, results){
+	results.splice(0, results.length)
+	_workingString.splice(0, _workingString.length)
+	for(let i=0; i < input.length; i++){
+		if(input[i] === separator){
+			results.push(_workingString.join(''))
+			_workingString.splice(0, _workingString.length)
+		} else {
+			_workingString.push(input[i])
+		}
+	}
+	if(_workingString.length > 0){
+		results.push(_workingString.join(''))
+	}
+	return results
+}
+
+let _workingString = []
+
+export { split }

--- a/src/filter/ClickFilter.js
+++ b/src/filter/ClickFilter.js
@@ -1,4 +1,5 @@
 import Filter from "./Filter.js";
+import { split } from '../MemoryUtils.js';
 
 /**
  * ClickFilter activates the action if input is truthy.
@@ -22,22 +23,30 @@ export default class ClickFilter extends Filter {
    *
    * @return {Array} [value, actionParameters]
    */
-  filter(inputPath, inputValue, filterPath, filterParameters) {
-    const target = this._getTarget(inputPath);
-    return [!!inputValue, { targetComponent: target }];
+  filter(inputPath, inputActive, inputValue, filterPath, filterParameters, results=null) {
+    if(results === null) results = new Array(2);
+    results[0] = inputActive
+    results[1] = this._getTarget(inputPath)
+    return results;
   }
 
   _getTarget(inputPath) {
     // Assumes that /1/2/target is the target where 1 and 2 are the first two tokens in the path
-    let tokens = inputPath.split("/");
-    if (tokens.length < 3) return null;
-    const targetPath = `/${tokens[1]}/${tokens[2]}/target`;
-    let targetEl = this._queryInputPath(targetPath)[0];
-    if (!targetEl) return null;
-    while (true) {
-      if (targetEl.component) return targetEl.component;
-      if (!targetEl.parentElement) return null;
-      targetEl = targetEl.parentElement;
+    split(inputPath, "/", _tokens);
+    if (_tokens.length < 3) return null;
+    _targetPath = `/${_tokens[1]}/${_tokens[2]}/target`;
+    this._queryInputPath(_targetPath, _queryResult);
+    if(_queryResult[0] === false) return null
+    let obj = _queryResult[1]
+    while(obj){
+      if(obj.component) return obj.component
+      obj = obj.parentNode
     }
+    return null
   }
 }
+
+let _targetPath = null
+let _tokens = []
+let _targetEl = null
+let _queryResult = new Array(2);

--- a/src/filter/Filter.js
+++ b/src/filter/Filter.js
@@ -6,13 +6,15 @@
 export default class Filter {
   /**
    * @param {string} inputPath
+   * @param {boolean} inputActive
    * @param inputValue
    * @param {string} filterPath
    * @param {Object} filterParameters parameters for use while filtering
+   * @param results an options three element array in which to set the results
    *
-   * @return {Array} [value, actionParameters]
+   * @return {Array} [active, value]
    */
-  filter(inputPath, inputValue, filterPath, filterParameters) {
+  filter(inputPath, inputActive, inputValue, filterPath, filterParameters, results=null) {
     throw new Error("Extending classes must override the filter method");
   }
 

--- a/src/filter/MinMaxFilter.js
+++ b/src/filter/MinMaxFilter.js
@@ -15,23 +15,55 @@ let MinMaxFilter = class extends Filter {
    *
    * @return {Array} [value, actionParameters]
    */
-  filter(inputPath, inputValue, filterPath, filterParameters) {
+  filter(inputPath, inputActive, inputValue, filterPath, filterParameters, results=null) {
+    if(results === null) results = new Array(2);
+    if(inputActive === false){
+      results[0] = false
+      results[1] = null
+      return results
+    }
     const input = Number.parseFloat(inputValue, 10);
-    if (Number.isNaN(input)) return [null, null];
+    if (Number.isNaN(input)) {
+      results[0] = false
+      results[1] = null
+      return results
+    }
     if ("minimum" in filterParameters) {
-      if (input < filterParameters["minimum"]) return [null, null];
+      if (input < filterParameters["minimum"]) {
+        results[0] = false
+        results[1] = null
+        return results
+      }
     } else {
-      if (input < MinMaxFilter.DefaultMinimum) return [null, null];
+      if (input < MinMaxFilter.DefaultMinimum) {
+        results[0] = false
+        results[1] = null
+        return results
+      }
     }
     if ("maximum" in filterParameters) {
-      if (input > filterParameters["maximum"]) return [null, null];
+      if (input > filterParameters["maximum"]){
+        results[0] = false
+        results[1] = null
+        return results
+      }
     } else {
-      if (input > MinMaxFilter.DefaultMaximum) return [null, null];
+      if (input > MinMaxFilter.DefaultMaximum){
+        results[0] = false
+        results[1] = null
+        return results
+      }
     }
     if ("minimum-absolute" in filterParameters) {
-      if (Math.abs(input) < filterParameters["minimum-absolute"]) return [null, null];
+      if (Math.abs(input) < filterParameters["minimum-absolute"]) {
+        results[0] = false
+        results[1] = null
+        return results
+      }
     }
-    return [input, {}];
+    results[0] = true;
+    results[1] = input;
+    return results;
   }
 
   /** @return {string} a human readable name */

--- a/src/filter/ReverseActiveFilter.js
+++ b/src/filter/ReverseActiveFilter.js
@@ -16,8 +16,11 @@ export default class ReverseActiveFilter extends Filter {
    *
    * @return {Array} [value, actionParameters]
    */
-  filter(inputPath, inputValue, filterPath, filterParameters) {
-    return [!inputValue, null];
+  filter(inputPath, inputActive, inputValue, filterPath, filterParameters, results=null) {
+    if (results === null) results = new Array(2);
+    results[0] = !inputActive;
+    results[1] = inputValue;
+    return results;
   }
 
   /** @return {string} a human readable name */

--- a/src/input/InputSource.js
+++ b/src/input/InputSource.js
@@ -10,9 +10,10 @@ export default class InputSource {
 
   /**
   @param partialPath {string} the relative semantic path for an input
-  @return the value of the the input, or null if the path does not exist
+  @param {Array} [result] a two element array [active, value]
+  @return {Array[active {boolean}, value]}
   */
-  queryInputPath(partialPath) {
+  queryInputPath(partialPath, result=null) {
     return null;
   }
 

--- a/src/input/KeyboardInputSource.js
+++ b/src/input/KeyboardInputSource.js
@@ -29,8 +29,12 @@ export default class KeyboardInputSource extends InputSource {
   @param partialPath {string} the relative semantic path for an input
   @return the value of the the input, or null if the path does not exist
   */
-  queryInputPath(partialPath) {
-    if (partialPath.startsWith("/0/key/") === false && partialPath.startsWith("/*/key/") === false) return null;
+  queryInputPath(partialPath, result=null) {
+    if(result === null) result = [false, null];
+
+    if (partialPath.startsWith("/0/key/") === false && partialPath.startsWith("/*/key/") === false) {
+      return result;
+    }
 
     const lastToken = partialPath.substring(7);
 
@@ -39,11 +43,13 @@ export default class KeyboardInputSource extends InputSource {
       for (let value of this._activeKeyCodes.values()) {
         values[values.length] = value;
       }
-      return values;
+      result[0] = values.length > 0
+      result[1] = values
     }
 
     let keycode = Number.parseInt(lastToken, 10);
-    if (Number.isNaN(keycode)) return null;
-    return this._activeKeyCodes.has(keycode);
+    if (Number.isNaN(keycode)) return result;
+    result[0] = this._activeKeyCodes.has(keycode);
+    return result
   }
 }

--- a/src/input/MouseInputSource.js
+++ b/src/input/MouseInputSource.js
@@ -46,10 +46,16 @@ export default class MouseInputSource extends InputSource {
   @param partialPath {string} the relative semantic path for an input
   @return the value of the the input, or null if the path does not exist
   */
-  queryInputPath(partialPath) {
-    if (partialPath === "/target") return this._target;
+  queryInputPath(partialPath, result) {
+    if(result === null) result = [false, null];
 
-    if (partialPath.startsWith("/0/") === false && partialPath.startsWith("/*/") === false) return null;
+    if (partialPath === "/target") {
+      result[0] = !!this._target;
+      result[1] = this._target;
+      return result
+    }
+
+    if (partialPath.startsWith("/0/") === false && partialPath.startsWith("/*/") === false) return result;
 
     const path = partialPath.substring(3);
 
@@ -57,36 +63,59 @@ export default class MouseInputSource extends InputSource {
       const specifier = path.substring(7);
       switch (specifier) {
         case "primary":
-          return !!this._buttons[0];
+          result[0] = !!this._buttons[0];
+          return result;
         case "secondary":
-          return !!this._buttons[1];
+          result[0] = !!this._buttons[1];
+          return result;
         case "tertiary":
-          return !!this._buttons[2];
+          result[0] = !!this._buttons[2];
+          return result;
         default:
           const index = Number.parseInt(path.substring(7), 10);
-          if (Number.isNaN(index)) return null;
-          return !!this._buttons[index];
+          if (Number.isNaN(index)) return result;
+          result[0] = !!this._buttons[index];
+          return result
       }
     }
 
     switch (path) {
       case "normalized-position":
-        return this._normalizedX === null ? null : [this._normalizedX, this._normalizedY];
+        result[1] = this._normalizedX === null ? null : [this._normalizedX, this._normalizedY];
+        result[0] = result[1] !== null
+        return result
+
       case "client-position":
-        return this._clientX === null ? null : [this._clientX, this._clientY];
+        result[1] = this._clientX === null ? null : [this._clientX, this._clientY];
+        result[0] = result[1] !== null
+        return result
+
       case "offset-position":
-        return this._offsetX === null ? null : [this._offsetX, this._offsetY];
+        result[1] = this._offsetX === null ? null : [this._offsetX, this._offsetY];
+        result[0] = result[1] !== null
+        return result
+
       case "screen-position":
-        return this._screenX === null ? null : [this._screenX, this._screenY];
+        result[1] = this._screenX === null ? null : [this._screenX, this._screenY];
+        result[0] = result[1] !== null
+        return result
+
       case "movement-position":
-        return this._movementX === null ? null : [this._movementX, this._movementY];
+        result[1] = this._movementX === null ? null : [this._movementX, this._movementY];
+        result[0] = result[1] !== null
+        return result
+
       case "app-position":
-        return this._appX === null ? null : [this._appX, this._appY];
+        result[1] = this._appX === null ? null : [this._appX, this._appY];
+        result[0] = result[1] !== null
+        return result
     }
+
+    return result
   }
 
   _updatePosition(event) {
-    this._target = event.target;
+    this._target = event.target || null;
     this._normalizedX = event.clientX / document.documentElement.offsetWidth * 2 - 1;
     this._normalizedY = -(event.clientY / document.documentElement.offsetHeight) * 2 + 1;
 

--- a/src/input/TouchInputSource.js
+++ b/src/input/TouchInputSource.js
@@ -26,28 +26,39 @@ export default class TouchInputSource extends InputSource {
   @param partialPath {string} the relative semantic path for an input
   @return the value of the the input, or null if the path does not exist
   */
-  queryInputPath(partialPath) {
+  queryInputPath(partialPath, result=null) {
+    if(result === null) result = [false, null];
+
     if (partialPath.startsWith("/touches/")) {
       const index = Number.parseInt(partialPath.substring(8));
-      if (Number.isNaN(index)) return null;
-      return this.item(index);
+      if (Number.isNaN(index)) return result;
+      result[1] = this.item(index);
+      result[0] = result[1] !== null
+      return result
     }
 
     if (partialPath.startsWith("/normalized-position/")) {
       const index = Number.parseInt(partialPath.substring(21));
-      if (Number.isNaN(index)) return null;
-      return this.normalizedPosition(index);
+      if (Number.isNaN(index)) return result;
+      result[1] = this.normalizedPosition(index);
+      result[0] = result[1] !== null
+      return result
     }
 
     switch (partialPath) {
       case "/count":
-        return this._touches === null ? 0 : this._touches.length;
+        result[1] = this._touches === null ? 0 : this._touches.length;
+        result[0] = result[1] > 0;
+        return result;
       case "/target":
-        return this._target;
+        result[1] = this._target;
+        result[0] = result[1] !== null;
+        return result;
       case "/touches":
-        return this.touches;
+        result[1] = this.touches;
+        result[0] = result[1].length > 0
       default:
-        return null;
+        return result;
     }
   }
 


### PR DESCRIPTION
I use action-input in [PotassiumES](https://potassiumes.org/) and (as @fernandojsg predicted) quickly ran into problems with per-frame heap allocation causing GC pauses in rendering.

The main code is ready for review but I need to update the example code.

This PR eliminates heap allocations during the `poll` by:
- passing reusable data structures instead of ephemeral new ones
- rewriting loops to use iteration methods that do not create new arrays or iterators
- creating per-module reusable (aka working) data structures instead of recreating them in methods
- filter and action parameters are passed instead of copying their values into new data structures

